### PR TITLE
feat: Add dark mode feature and toggle

### DIFF
--- a/supa-nuxt/assets/css/main.css
+++ b/supa-nuxt/assets/css/main.css
@@ -589,3 +589,18 @@ header {
         max-width: 100%;
     }
 }
+
+/* Dark Mode Variables */
+html.dark {
+    --primary: #4361ee; /* Maintained for consistency, adjust if needed for better dark mode aesthetics */
+    --secondary: #3f37c9; /* Maintained for consistency */
+    --accent: #4895ef; /* Maintained for consistency */
+    --background: #121212; /* Common dark theme background */
+    --card: #1e1e1e; /* Slightly lighter than background for cards/elevated surfaces */
+    --text: #e0e0e0; /* Light gray for readable text on dark backgrounds */
+    --text-light: #a0a0a0; /* Softer light gray for secondary text */
+    --danger: #e63946; /* Often kept same, but check contrast if issues arise */
+    --success: #2a9d8f; /* Often kept same */
+    --warning: #f4a261; /* Often kept same */
+    --shadow: 0 4px 8px rgba(0, 0, 0, 0.3); /* Darker, more diffused shadow for dark themes */
+}

--- a/supa-nuxt/components/AppHeader.vue
+++ b/supa-nuxt/components/AppHeader.vue
@@ -20,13 +20,22 @@
           <span id="status-text">{{ isConnected ? 'Connected' : 'Disconnected' }}</span>
         </div>
         <div class="status-badge">
-          <iframe src="https://status.harshalmore.dev/badge?theme=light" width="250" height="32" frameborder="0" scrolling="no" style="color-scheme: normal"></iframe>
+          <iframe :src="iframeSrc" width="250" height="32" frameborder="0" scrolling="no" style="color-scheme: normal"></iframe>
         </div>
+        <button @click="toggleColorMode" class="color-mode-toggle-btn" aria-label="Toggle color mode">
+          <i v-if="colorModeValue === 'light'" class="fas fa-sun"></i>
+          <i v-else class="fas fa-moon"></i>
+        </button>
       </div>
     </header>
   </template>
   
   <script setup>
+import { computed } from 'vue';
+import { useColorModeExtended } from '~/composables/useColorMode';
+
+const { colorModeValue, toggleColorMode } = useColorModeExtended();
+
   defineProps({
     searchTerm: String,
     isConnected: Boolean
@@ -36,6 +45,11 @@
   const reloadPage = () => {
       window.location.reload();
   }
+
+const iframeSrc = computed(() => {
+  const theme = colorModeValue.value === 'dark' ? 'dark' : 'light';
+  return `https://status.harshalmore.dev/badge?theme=${theme}`;
+});
   </script>
   
   <style scoped>
@@ -78,4 +92,32 @@
       margin-bottom: 5px;
     }
   }
+
+/* Styles for the color mode toggle button */
+.color-mode-toggle-btn {
+  background: none;
+  border: none;
+  color: var(--text); /* Use CSS variable for color */
+  cursor: pointer;
+  font-size: 1.2rem; /* Adjust size as needed */
+  padding: 5px;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px; /* Match height of status indicator/badge for alignment */
+  height: 32px; /* Match height of status indicator/badge for alignment */
+}
+
+.color-mode-toggle-btn:hover {
+  background-color: rgba(0,0,0,0.05); /* Subtle hover effect for light mode */
+}
+
+html.dark .color-mode-toggle-btn { /* Style for dark mode */
+  color: var(--text); /* Ensure it uses the dark mode text color */
+}
+
+html.dark .color-mode-toggle-btn:hover {
+  background-color: rgba(255,255,255,0.1); /* Subtle hover effect for dark mode */
+}
   </style>

--- a/supa-nuxt/composables/useColorMode.ts
+++ b/supa-nuxt/composables/useColorMode.ts
@@ -1,4 +1,4 @@
-import { useColorMode } from '@nuxtjs/color-mode';
+import { useColorMode } from '#imports';
 
 export const useColorModeExtended = () => {
   const colorMode = useColorMode();

--- a/supa-nuxt/composables/useColorMode.ts
+++ b/supa-nuxt/composables/useColorMode.ts
@@ -1,0 +1,19 @@
+import { useColorMode } from '@nuxtjs/color-mode';
+
+export const useColorModeExtended = () => {
+  const colorMode = useColorMode();
+
+  const toggleColorMode = () => {
+    if (colorMode.preference === 'dark') {
+      colorMode.preference = 'light';
+    } else {
+      colorMode.preference = 'dark';
+    }
+  };
+
+  return {
+    colorModePreference: colorMode.preference, // Expose preference (e.g., 'light', 'dark', 'system')
+    colorModeValue: colorMode.value, // Expose the resolved value (e.g., 'light' or 'dark')
+    toggleColorMode,
+  };
+};


### PR DESCRIPTION
Implemented a dark mode feature for the Nuxt application.

Key changes include:

- Enabled Nuxt UI's color mode functionality.
- Added dark theme color variables to `assets/css/main.css` under an `html.dark` selector.
- Created a `useColorModeExtended` composable (`composables/useColorMode.ts`) to manage and toggle the color mode preference.
- Integrated a toggle button into `components/AppHeader.vue`:
    - The button displays a sun/moon icon based on the current mode.
    - Clicking the button switches between light and dark themes.
    - The status badge iframe theme in the header now dynamically updates based on the selected color mode.
- The `@nuxtjs/color-mode` module handles applying the appropriate class to the HTML element, and CSS variables ensure theme application.

Manual testing is required to verify visual consistency and functionality across the application.